### PR TITLE
Fix printing for New-OsmParentRota and Get-OsmPaperRegister

### DIFF
--- a/Osm.PowerShell.Tools.ps1
+++ b/Osm.PowerShell.Tools.ps1
@@ -103,7 +103,7 @@ function New-OsmParentRota {
   $assignments | ConvertTo-Html @htmlParams | Out-File $downloadsPath\parent_rota_$sectionNameFile.html
 
   if ($print) {
-    Get-Content $downloadsPath\parent_rota_$sectionNameFile.html | Out-Printer
+    Out-Printer -Name "$downloadsPath\parent_rota_$sectionNameFile.html"
   }
 }
 function Get-OsmPaperRegister {
@@ -136,7 +136,7 @@ function Get-OsmPaperRegister {
   Write-Output "✅ Register downloaded to $downloadsPath\paper_register_$sectionNameFile.pdf"
 
   if ($print) {
-    Get-Content $downloadsPath\paper_register_$sectionNameFile.pdf | Out-Printer
+    Out-Printer -Name "$downloadsPath\paper_register_$sectionNameFile.pdf"
   }
 }
 function New-OsmMeetings {


### PR DESCRIPTION
Fixed the printing functionality for both functions by using `Out-Printer -Name` with file paths instead of piping `Get-Content` output.

This ensures files are sent to the printer properly instead of outputting raw HTML/PDF binary data.

Fixes #6

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/lukelloyd1985/osm-powershell-tools/actions/runs/21805742601