### PR TITLE
Fix print parameter for New-OsmParentRota and Get-OsmPaperRegister

### DIFF
--- a/Osm.PowerShell.Tools.ps1
+++ b/Osm.PowerShell.Tools.ps1
@@ -219,7 +219,7 @@ function New-OsmParentRota {
   $assignments | ConvertTo-Html @htmlParams | Out-File $outputFile
 
   if ($print) {
-    Out-Printer -Name $outputFile
+    Start-Process -FilePath $outputFile -Verb Print
   }
 
   Write-Host "✅ Parent rota saved to $outputFile"
@@ -283,7 +283,7 @@ function Get-OsmPaperRegister {
   Invoke-OsmApi -url $printRegisterUrlWithParams -method "DOWNLOAD" -file $outputFile
 
   if ($print) {
-    Out-Printer -Name $outputFile
+    Start-Process -FilePath $outputFile -Verb Print
   }
 
   Write-Host "✅ Register downloaded to $outputFile"


### PR DESCRIPTION
## Summary
- Fixed `New-OsmParentRota` to use Start-Process with Print verb for HTML files
- Fixed `Get-OsmPaperRegister` to use Start-Process with Print verb for PDF files
- Both functions now properly render and print content instead of printing raw data

Fixes #26

Generated with [Claude Code](https://claude.ai/code)