### PR TITLE
Fix print parameter for New-OsmParentRota and Get-OsmPaperRegister

### DIFF
--- a/Osm.PowerShell.Tools.ps1
+++ b/Osm.PowerShell.Tools.ps1
@@ -151,12 +151,17 @@ function ConvertTo-PdfForPrinting {
     -NoNewWindow `
     -Wait `
     -PassThru `
-    -RedirectStandardOutput $null `
+    -RedirectStandardOutput "$env:TEMP\edge-stdout.txt" `
     -RedirectStandardError "$env:TEMP\edge-stderr.txt"
 
   # Clean up stderr temp file
   if (Test-Path "$env:TEMP\edge-stderr.txt") {
     Remove-Item "$env:TEMP\edge-stderr.txt" -Force -ErrorAction SilentlyContinue
+  }
+
+  # Clean up stdout temp file
+  if (Test-Path "$env:TEMP\edge-stdout.txt") {
+    Remove-Item "$env:TEMP\edge-stdout.txt" -Force -ErrorAction SilentlyContinue
   }
 
   if ($process.ExitCode -ne 0) {


### PR DESCRIPTION
## Summary
- Add ConvertTo-PdfForPrinting helper function to convert HTML to PDF using Edge/Chrome headless
- Update New-OsmParentRota to convert HTML to PDF before printing
- Update both functions to use Start-Process with Print verb and process management
- Set sleep duration to 5 seconds to allow print dialog to appear
- Add automatic PDF viewer cleanup after printing
- Include error handling for print failures
- Suppress stderr output by redirecting to temp file instead of using -RedirectStandardError with null

Fixes #26

Generated with [Claude Code](https://claude.ai/code)